### PR TITLE
chore: update losses 2025-01-26

### DIFF
--- a/data/en-US.json
+++ b/data/en-US.json
@@ -1,5 +1,23 @@
 [
   {
+    "date": "2025-01-26",
+    "sourceUri": "https://www.mil.gov.ua/news/zagalni-bojovi-vtrati-rosiyan-za-dobu-1-720-okupantiv-40-bpla-ta-14-artsistem",
+    "personnel": 830190,
+    "tanks": 9868,
+    "afvs": 20549,
+    "artillery": 22323,
+    "airDefense": 1050,
+    "rocketSystems": 1263,
+    "unarmoredVehicles": 35124,
+    "fixedWingAircraft": 369,
+    "rotoryWingAircraft": 331,
+    "uavs": 23253,
+    "ships": 28,
+    "submarines": 1,
+    "specialEquipment": 3715,
+    "missiles": 3053
+  },
+  {
     "date": "2025-01-25",
     "sourceUri": "https://www.mil.gov.ua/news/zagalni-bojovi-vtrati-rosiyan-za-dobu-1-650-okupantiv-51-bpla-ta-14-artsistem",
     "personnel": 828470,


### PR DESCRIPTION
# Russian losses in Ukraine 2025-01-26 - 2025-01-25
  Source: https://www.mil.gov.ua/news/zagalni-bojovi-vtrati-rosiyan-za-dobu-1-720-okupantiv-40-bpla-ta-14-artsistem

  ```diff
  @@ personnel @@
  - 828470
  + 830190
  # 1720 difference

  @@ artillery @@
  - 22309
  + 22323
  # 14 difference

  @@ fixedWingAircraft @@
  - 369
  + 369
  # 0 difference

  @@ rotoryWingAircraft @@
  - 331
  + 331
  # 0 difference

  @@ tanks @@
  - 9859
  + 9868
  # 9 difference

  @@ afvs @@
  - 20545
  + 20549
  # 4 difference

  @@ rocketSystems @@
  - 1263
  + 1263
  # 0 difference

  @@ airDefense @@
  - 1050
  + 1050
  # 0 difference

  @@ ships @@
  - 28
  + 28
  # 0 difference

  @@ submarines @@
  - 1
  + 1
  # 0 difference

  @@ unarmoredVehicles @@
  - 35071
  + 35124
  # 53 difference

  @@ specialEquipment @@
  - 3715
  + 3715
  # 0 difference

  @@ uavs @@
  - 23213
  + 23253
  # 40 difference

  @@ missiles @@
  - 3053
  + 3053
  # 0 difference

  ```
  