### PR TITLE
chore: update losses 2025-01-27

### DIFF
--- a/data/en-US.json
+++ b/data/en-US.json
@@ -1,5 +1,23 @@
 [
   {
+    "date": "2025-01-27",
+    "sourceUri": "https://www.mil.gov.ua/news/zagalni-bojovi-vtrati-rosiyan-za-dobu-1-430-okupantiv-74-bpla-ta-16-artsistem",
+    "personnel": 831620,
+    "tanks": 9871,
+    "afvs": 20561,
+    "artillery": 22339,
+    "airDefense": 1050,
+    "rocketSystems": 1263,
+    "unarmoredVehicles": 35183,
+    "fixedWingAircraft": 369,
+    "rotoryWingAircraft": 331,
+    "uavs": 23327,
+    "ships": 28,
+    "submarines": 1,
+    "specialEquipment": 3716,
+    "missiles": 3053
+  },
+  {
     "date": "2025-01-26",
     "sourceUri": "https://www.mil.gov.ua/news/zagalni-bojovi-vtrati-rosiyan-za-dobu-1-720-okupantiv-40-bpla-ta-14-artsistem",
     "personnel": 830190,


### PR DESCRIPTION
# Russian losses in Ukraine 2025-01-27 - 2025-01-26
  Source: https://www.mil.gov.ua/news/zagalni-bojovi-vtrati-rosiyan-za-dobu-1-430-okupantiv-74-bpla-ta-16-artsistem

  ```diff
  @@ personnel @@
  - 830190
  + 831620
  # 1430 difference

  @@ artillery @@
  - 22323
  + 22339
  # 16 difference

  @@ fixedWingAircraft @@
  - 369
  + 369
  # 0 difference

  @@ rotoryWingAircraft @@
  - 331
  + 331
  # 0 difference

  @@ tanks @@
  - 9868
  + 9871
  # 3 difference

  @@ afvs @@
  - 20549
  + 20561
  # 12 difference

  @@ rocketSystems @@
  - 1263
  + 1263
  # 0 difference

  @@ airDefense @@
  - 1050
  + 1050
  # 0 difference

  @@ ships @@
  - 28
  + 28
  # 0 difference

  @@ submarines @@
  - 1
  + 1
  # 0 difference

  @@ unarmoredVehicles @@
  - 35124
  + 35183
  # 59 difference

  @@ specialEquipment @@
  - 3715
  + 3716
  # 1 difference

  @@ uavs @@
  - 23253
  + 23327
  # 74 difference

  @@ missiles @@
  - 3053
  + 3053
  # 0 difference

  ```
  