### PR TITLE
chore: update losses 2025-01-28

### DIFF
--- a/data/en-US.json
+++ b/data/en-US.json
@@ -1,5 +1,23 @@
 [
   {
+    "date": "2025-01-28",
+    "sourceUri": "https://www.mil.gov.ua/news/zagalni-bojovi-vtrati-rosiyan-za-dobu-1-380-okupantiv-72-bpla-ta-27-artsistem",
+    "personnel": 833000,
+    "tanks": 9876,
+    "afvs": 20573,
+    "artillery": 22366,
+    "airDefense": 1050,
+    "rocketSystems": 1263,
+    "unarmoredVehicles": 35269,
+    "fixedWingAircraft": 369,
+    "rotoryWingAircraft": 331,
+    "uavs": 23399,
+    "ships": 28,
+    "submarines": 1,
+    "specialEquipment": 3718,
+    "missiles": 3053
+  },
+  {
     "date": "2025-01-27",
     "sourceUri": "https://www.mil.gov.ua/news/zagalni-bojovi-vtrati-rosiyan-za-dobu-1-430-okupantiv-74-bpla-ta-16-artsistem",
     "personnel": 831620,


### PR DESCRIPTION
# Russian losses in Ukraine 2025-01-28 - 2025-01-27
  Source: https://www.mil.gov.ua/news/zagalni-bojovi-vtrati-rosiyan-za-dobu-1-380-okupantiv-72-bpla-ta-27-artsistem

  ```diff
  @@ personnel @@
  - 831620
  + 833000
  # 1380 difference

  @@ artillery @@
  - 22339
  + 22366
  # 27 difference

  @@ fixedWingAircraft @@
  - 369
  + 369
  # 0 difference

  @@ rotoryWingAircraft @@
  - 331
  + 331
  # 0 difference

  @@ tanks @@
  - 9871
  + 9876
  # 5 difference

  @@ afvs @@
  - 20561
  + 20573
  # 12 difference

  @@ rocketSystems @@
  - 1263
  + 1263
  # 0 difference

  @@ airDefense @@
  - 1050
  + 1050
  # 0 difference

  @@ ships @@
  - 28
  + 28
  # 0 difference

  @@ submarines @@
  - 1
  + 1
  # 0 difference

  @@ unarmoredVehicles @@
  - 35183
  + 35269
  # 86 difference

  @@ specialEquipment @@
  - 3716
  + 3718
  # 2 difference

  @@ uavs @@
  - 23327
  + 23399
  # 72 difference

  @@ missiles @@
  - 3053
  + 3053
  # 0 difference

  ```
  