### PR TITLE
chore: update losses 2025-01-29

### DIFF
--- a/data/en-US.json
+++ b/data/en-US.json
@@ -1,5 +1,23 @@
 [
   {
+    "date": "2025-01-29",
+    "sourceUri": "https://www.mil.gov.ua/news/zagalni-bojovi-vtrati-rosiyan-za-dobu-1-670-okupantiv-57-bpla-ta-29-artsistem",
+    "personnel": 834670,
+    "tanks": 9886,
+    "afvs": 20597,
+    "artillery": 22395,
+    "airDefense": 1050,
+    "rocketSystems": 1264,
+    "unarmoredVehicles": 35366,
+    "fixedWingAircraft": 369,
+    "rotoryWingAircraft": 331,
+    "uavs": 23456,
+    "ships": 28,
+    "submarines": 1,
+    "specialEquipment": 3721,
+    "missiles": 3054
+  },
+  {
     "date": "2025-01-28",
     "sourceUri": "https://www.mil.gov.ua/news/zagalni-bojovi-vtrati-rosiyan-za-dobu-1-380-okupantiv-72-bpla-ta-27-artsistem",
     "personnel": 833000,


### PR DESCRIPTION
# Russian losses in Ukraine 2025-01-29 - 2025-01-28
  Source: https://www.mil.gov.ua/news/zagalni-bojovi-vtrati-rosiyan-za-dobu-1-670-okupantiv-57-bpla-ta-29-artsistem

  ```diff
  @@ personnel @@
  - 833000
  + 834670
  # 1670 difference

  @@ artillery @@
  - 22366
  + 22395
  # 29 difference

  @@ fixedWingAircraft @@
  - 369
  + 369
  # 0 difference

  @@ rotoryWingAircraft @@
  - 331
  + 331
  # 0 difference

  @@ tanks @@
  - 9876
  + 9886
  # 10 difference

  @@ afvs @@
  - 20573
  + 20597
  # 24 difference

  @@ rocketSystems @@
  - 1263
  + 1264
  # 1 difference

  @@ airDefense @@
  - 1050
  + 1050
  # 0 difference

  @@ ships @@
  - 28
  + 28
  # 0 difference

  @@ submarines @@
  - 1
  + 1
  # 0 difference

  @@ unarmoredVehicles @@
  - 35269
  + 35366
  # 97 difference

  @@ specialEquipment @@
  - 3718
  + 3721
  # 3 difference

  @@ uavs @@
  - 23399
  + 23456
  # 57 difference

  @@ missiles @@
  - 3053
  + 3054
  # 1 difference

  ```
  