### PR TITLE
chore: update losses 2025-01-30

### DIFF
--- a/data/en-US.json
+++ b/data/en-US.json
@@ -1,5 +1,23 @@
 [
   {
+    "date": "2025-01-30",
+    "sourceUri": "https://www.mil.gov.ua/news/zagalni-bojovi-vtrati-rosiyan-za-dobu-1-270-okupantiv-54-bpla-ta-17-artsistem",
+    "personnel": 835940,
+    "tanks": 9890,
+    "afvs": 20614,
+    "artillery": 22412,
+    "airDefense": 1050,
+    "rocketSystems": 1264,
+    "unarmoredVehicles": 35451,
+    "fixedWingAircraft": 369,
+    "rotoryWingAircraft": 331,
+    "uavs": 23510,
+    "ships": 28,
+    "submarines": 1,
+    "specialEquipment": 3725,
+    "missiles": 3054
+  },
+  {
     "date": "2025-01-29",
     "sourceUri": "https://www.mil.gov.ua/news/zagalni-bojovi-vtrati-rosiyan-za-dobu-1-670-okupantiv-57-bpla-ta-29-artsistem",
     "personnel": 834670,


### PR DESCRIPTION
# Russian losses in Ukraine 2025-01-30 - 2025-01-29
  Source: https://www.mil.gov.ua/news/zagalni-bojovi-vtrati-rosiyan-za-dobu-1-270-okupantiv-54-bpla-ta-17-artsistem

  ```diff
  @@ personnel @@
  - 834670
  + 835940
  # 1270 difference

  @@ artillery @@
  - 22395
  + 22412
  # 17 difference

  @@ fixedWingAircraft @@
  - 369
  + 369
  # 0 difference

  @@ rotoryWingAircraft @@
  - 331
  + 331
  # 0 difference

  @@ tanks @@
  - 9886
  + 9890
  # 4 difference

  @@ afvs @@
  - 20597
  + 20614
  # 17 difference

  @@ rocketSystems @@
  - 1264
  + 1264
  # 0 difference

  @@ airDefense @@
  - 1050
  + 1050
  # 0 difference

  @@ ships @@
  - 28
  + 28
  # 0 difference

  @@ submarines @@
  - 1
  + 1
  # 0 difference

  @@ unarmoredVehicles @@
  - 35366
  + 35451
  # 85 difference

  @@ specialEquipment @@
  - 3721
  + 3725
  # 4 difference

  @@ uavs @@
  - 23456
  + 23510
  # 54 difference

  @@ missiles @@
  - 3054
  + 3054
  # 0 difference

  ```
  