### PR TITLE
chore: update losses 2025-01-31

### DIFF
--- a/data/en-US.json
+++ b/data/en-US.json
@@ -1,5 +1,23 @@
 [
   {
+    "date": "2025-01-31",
+    "sourceUri": "https://www.mil.gov.ua/news/zagalni-bojovi-vtrati-rosiyan-za-dobu-1-670-okupantiv-63-bpla-ta-17-artsistem",
+    "personnel": 837610,
+    "tanks": 9893,
+    "afvs": 20631,
+    "artillery": 22445,
+    "airDefense": 1050,
+    "rocketSystems": 1265,
+    "unarmoredVehicles": 35552,
+    "fixedWingAircraft": 369,
+    "rotoryWingAircraft": 331,
+    "uavs": 23573,
+    "ships": 28,
+    "submarines": 1,
+    "specialEquipment": 3726,
+    "missiles": 3054
+  },
+  {
     "date": "2025-01-30",
     "sourceUri": "https://www.mil.gov.ua/news/zagalni-bojovi-vtrati-rosiyan-za-dobu-1-270-okupantiv-54-bpla-ta-17-artsistem",
     "personnel": 835940,


### PR DESCRIPTION
# Russian losses in Ukraine 2025-01-31 - 2025-01-30
  Source: https://www.mil.gov.ua/news/zagalni-bojovi-vtrati-rosiyan-za-dobu-1-670-okupantiv-63-bpla-ta-17-artsistem

  ```diff
  @@ personnel @@
  - 835940
  + 837610
  # 1670 difference

  @@ artillery @@
  - 22412
  + 22445
  # 33 difference

  @@ fixedWingAircraft @@
  - 369
  + 369
  # 0 difference

  @@ rotoryWingAircraft @@
  - 331
  + 331
  # 0 difference

  @@ tanks @@
  - 9890
  + 9893
  # 3 difference

  @@ afvs @@
  - 20614
  + 20631
  # 17 difference

  @@ rocketSystems @@
  - 1264
  + 1265
  # 1 difference

  @@ airDefense @@
  - 1050
  + 1050
  # 0 difference

  @@ ships @@
  - 28
  + 28
  # 0 difference

  @@ submarines @@
  - 1
  + 1
  # 0 difference

  @@ unarmoredVehicles @@
  - 35451
  + 35552
  # 101 difference

  @@ specialEquipment @@
  - 3725
  + 3726
  # 1 difference

  @@ uavs @@
  - 23510
  + 23573
  # 63 difference

  @@ missiles @@
  - 3054
  + 3054
  # 0 difference

  ```
  