### PR TITLE
chore: update losses 2025-02-01

### DIFF
--- a/data/en-US.json
+++ b/data/en-US.json
@@ -1,5 +1,23 @@
 [
   {
+    "date": "2025-02-01",
+    "sourceUri": "https://www.mil.gov.ua/news/zagalni-bojovi-vtrati-rosiyan-za-dobu-1-430-okupantiv-121-bpla-ta-48-artsistem",
+    "personnel": 839040,
+    "tanks": 9902,
+    "afvs": 20653,
+    "artillery": 22493,
+    "airDefense": 1050,
+    "rocketSystems": 1266,
+    "unarmoredVehicles": 35629,
+    "fixedWingAircraft": 369,
+    "rotoryWingAircraft": 331,
+    "uavs": 23694,
+    "ships": 28,
+    "submarines": 1,
+    "specialEquipment": 3727,
+    "missiles": 3054
+  },
+  {
     "date": "2025-01-31",
     "sourceUri": "https://www.mil.gov.ua/news/zagalni-bojovi-vtrati-rosiyan-za-dobu-1-670-okupantiv-63-bpla-ta-17-artsistem",
     "personnel": 837610,


### PR DESCRIPTION
# Russian losses in Ukraine 2025-02-01 - 2025-01-31
  Source: https://www.mil.gov.ua/news/zagalni-bojovi-vtrati-rosiyan-za-dobu-1-430-okupantiv-121-bpla-ta-48-artsistem

  ```diff
  @@ personnel @@
  - 837610
  + 839040
  # 1430 difference

  @@ artillery @@
  - 22445
  + 22493
  # 48 difference

  @@ fixedWingAircraft @@
  - 369
  + 369
  # 0 difference

  @@ rotoryWingAircraft @@
  - 331
  + 331
  # 0 difference

  @@ tanks @@
  - 9893
  + 9902
  # 9 difference

  @@ afvs @@
  - 20631
  + 20653
  # 22 difference

  @@ rocketSystems @@
  - 1265
  + 1266
  # 1 difference

  @@ airDefense @@
  - 1050
  + 1050
  # 0 difference

  @@ ships @@
  - 28
  + 28
  # 0 difference

  @@ submarines @@
  - 1
  + 1
  # 0 difference

  @@ unarmoredVehicles @@
  - 35552
  + 35629
  # 77 difference

  @@ specialEquipment @@
  - 3726
  + 3727
  # 1 difference

  @@ uavs @@
  - 23573
  + 23694
  # 121 difference

  @@ missiles @@
  - 3054
  + 3054
  # 0 difference

  ```
  