### PR TITLE
chore: update losses 2025-02-02

### DIFF
--- a/data/en-US.json
+++ b/data/en-US.json
@@ -1,5 +1,23 @@
 [
   {
+    "date": "2025-02-02",
+    "sourceUri": "https://www.mil.gov.ua/news/zagalni-bojovi-vtrati-rosiyan-za-dobu-1-320-okupantiv-99-bpla-ta-45-artsistem",
+    "personnel": 840360,
+    "tanks": 9908,
+    "afvs": 20667,
+    "artillery": 22538,
+    "airDefense": 1050,
+    "rocketSystems": 1267,
+    "unarmoredVehicles": 35709,
+    "fixedWingAircraft": 369,
+    "rotoryWingAircraft": 331,
+    "uavs": 23793,
+    "ships": 28,
+    "submarines": 1,
+    "specialEquipment": 3729,
+    "missiles": 3054
+  },
+  {
     "date": "2025-02-01",
     "sourceUri": "https://www.mil.gov.ua/news/zagalni-bojovi-vtrati-rosiyan-za-dobu-1-430-okupantiv-121-bpla-ta-48-artsistem",
     "personnel": 839040,


### PR DESCRIPTION
# Russian losses in Ukraine 2025-02-02 - 2025-02-01
  Source: https://www.mil.gov.ua/news/zagalni-bojovi-vtrati-rosiyan-za-dobu-1-320-okupantiv-99-bpla-ta-45-artsistem

  ```diff
  @@ personnel @@
  - 839040
  + 840360
  # 1320 difference

  @@ artillery @@
  - 22493
  + 22538
  # 45 difference

  @@ fixedWingAircraft @@
  - 369
  + 369
  # 0 difference

  @@ rotoryWingAircraft @@
  - 331
  + 331
  # 0 difference

  @@ tanks @@
  - 9902
  + 9908
  # 6 difference

  @@ afvs @@
  - 20653
  + 20667
  # 14 difference

  @@ rocketSystems @@
  - 1266
  + 1267
  # 1 difference

  @@ airDefense @@
  - 1050
  + 1050
  # 0 difference

  @@ ships @@
  - 28
  + 28
  # 0 difference

  @@ submarines @@
  - 1
  + 1
  # 0 difference

  @@ unarmoredVehicles @@
  - 35629
  + 35709
  # 80 difference

  @@ specialEquipment @@
  - 3727
  + 3729
  # 2 difference

  @@ uavs @@
  - 23694
  + 23793
  # 99 difference

  @@ missiles @@
  - 3054
  + 3054
  # 0 difference

  ```
  