### PR TITLE
fix(losses): fixed 2025-01-20 afv

### DIFF
--- a/russian-losses.json
+++ b/russian-losses.json
@@ -2380,7 +2380,7 @@
     "sourceUri": "https://mod.gov.ua/news/zagalni-bojovi-vtrati-rosiyan-za-dobu-1-690-okupantiv-153-bpla-ta-19-artsistem",
     "personnel": 820430,
     "tanks": 9821,
-    "afvs": 2054,
+    "afvs": 20454,
     "artillery": 22074,
     "airDefense": 1049,
     "rocketSystems": 1262,


### PR DESCRIPTION
Fixed a typo in the `afvs` count for 2025-01-20.

20412 + 42 = 20454 which was typoed as 2045

https://mod.gov.ua/news/zagalni-bojovi-vtrati-rosiyan-za-dobu-1-690-okupantiv-153-bpla-ta-19-artsistem