### PR TITLE
chore: losses update 2025-07-24

### DIFF
--- a/russian-losses.json
+++ b/russian-losses.json
@@ -1,5 +1,23 @@
 [
   {
+    "date": "2025-07-24",
+    "sourceUri": "https://mod.gov.ua/news/zagalni-bojovi-vtrati-rosiyan-za-dobu-1-050-osib-86-bpla-ta-24-artsistemi",
+    "personnel": 1046270,
+    "tanks": 11046,
+    "afvs": 23047,
+    "artillery": 30746,
+    "airDefense": 1199,
+    "rocketSystems": 1446,
+    "unarmoredVehicles": 56137,
+    "fixedWingAircraft": 442,
+    "rotaryWingAircraft": 340,
+    "uavs": 47638,
+    "ships": 28,
+    "submarines": 1,
+    "specialEquipment": 3935,
+    "missiles": 3533
+  },
+  {
     "date": "2025-07-23",
     "sourceUri": "https://mod.gov.ua/news/zagalni-bojovi-vtrati-rosiyan-za-dobu-970-osib-115-bpla-ta-42-artsistemi-1",
     "personnel": 1045220,


### PR DESCRIPTION
Manually updating while orc-losses-bot figures out it's life 

https://mod.gov.ua/news/zagalni-bojovi-vtrati-rosiyan-za-dobu-1-050-osib-86-bpla-ta-24-artsistemi

personnel ‒ about 1,046,270 (+1,050) people
tanks ‒ 11,046 (+5) 
armored combat vehicles ‒ 23,047 (+10) 
artillery systems – 30,746 (+24) 
RSZV – 1 446 (+0) 
air defense equipment ‒ 1 199 (+0) 
aircraft – 421 (+0) 
helicopters – 340 (+0)
UAV operational-tactical – 47 638 (+86) 
cruise missiles ‒ 3 533 (+0) 
ships /boats ‒ 28 (+0) 
submarines - 1 (+0)
automotive equipment and tankers – 56 137 (+96)
special equipment ‒ 3,935 (+0) 