### PR TITLE
Add Jekyll lastmod timestamps to sitemap

### DIFF
--- a/docs/sitemap.xml
+++ b/docs/sitemap.xml
@@ -1,32 +1,41 @@
+---
+layout: none
+---
 <?xml version="1.0" encoding="UTF-8"?>
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
   <url>
     <loc>https://www.ukrainewarlosses.com</loc>
+    <lastmod>{{ site.time | date_to_xmlschema }}</lastmod>
     <changefreq>daily</changefreq>
     <priority>1.00</priority>
   </url>
   <url>
     <loc>https://www.ukrainewarlosses.com/uk</loc>
+    <lastmod>{{ site.time | date_to_xmlschema }}</lastmod>
     <changefreq>daily</changefreq>
     <priority>1.00</priority>
   </url>
   <url>
     <loc>https://www.ukrainewarlosses.com/fr</loc>
+    <lastmod>{{ site.time | date_to_xmlschema }}</lastmod>
     <changefreq>daily</changefreq>
     <priority>1.00</priority>
   </url>
   <url>
     <loc>https://www.ukrainewarlosses.com/de</loc>
+    <lastmod>{{ site.time | date_to_xmlschema }}</lastmod>
     <changefreq>daily</changefreq>
     <priority>1.00</priority>
   </url>
   <url>
     <loc>https://www.ukrainewarlosses.com/ua</loc>
+    <lastmod>{{ site.time | date_to_xmlschema }}</lastmod>
     <changefreq>daily</changefreq>
     <priority>1.00</priority>
   </url>
   <url>
     <loc>https://www.ukrainewarlosses.com/ru</loc>
+    <lastmod>{{ site.time | date_to_xmlschema }}</lastmod>
     <changefreq>daily</changefreq>
     <priority>1.00</priority>
   </url>


### PR DESCRIPTION
## Summary
- add Jekyll front matter to sitemap so Liquid renders
- include `lastmod` timestamp for each URL

## Testing
- `jekyll build -s docs -d docs/_site`


------
https://chatgpt.com/codex/tasks/task_e_68a18e34ed0c832f9f23dcdd81c5b307