### PR TITLE
chore: 2026 annual copyright update

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -9,6 +9,8 @@ See the LICENSE file in each directory for applicable licenses.
 
 MIT License
 
+Copyright (c) 2022-2026 Lod Softworks LLC
+
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal
 in the Software without restriction, including without limitation the rights

--- a/docs/icon/LICENSE.md
+++ b/docs/icon/LICENSE.md
@@ -2,6 +2,8 @@
 
 Icons used with attribution via the [Flaticon License](https://www.flaticon.com/legal)
 
+Copyright (c) 2022-2026 Lod Softworks LLC
+
 
 ## Attribution
 


### PR DESCRIPTION
### Motivation
- Update project copyright notices to a year-range ending in 2026.
- Standardize single-year copyrights to ranges where appropriate.
- Ensure license and attribution files accurately reflect the coverage period.

### Description
- Added `Copyright (c) 2022-2026 Lod Softworks LLC` to `LICENSE.md`.
- Added the same copyright line to `docs/icon/LICENSE.md`.
- Changes were made on branch `chore/2026-update` and a pull request titled `chore: 2026 annual copyright update` was opened.

### Testing
- No automated tests were run for this change.
- Changes are limited to documentation/license files and do not affect build or runtime code.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695a2ac5fee0832fa5f92a82c45b1ccb)