### PR TITLE
chore: raise UAV daily validation limit to 2500

### DIFF
--- a/.github/workflows/pr-loss-auto-check/index.js
+++ b/.github/workflows/pr-loss-auto-check/index.js
@@ -25,7 +25,7 @@ assert("ships", 50);
 assert("submarines", 50);
 assert("unarmoredVehicles", 250);
 assert("specialEquipment", 250);
-assert("uavs", 1000);
+assert("uavs", 2500);
 assert("missiles", 1000);
 
 console.log("All validations have completed successfully.");


### PR DESCRIPTION
### Motivation
- Relax the daily delta validation for UAVs to account for larger reported daily changes by increasing the allowed threshold from `1000` to `2500`.

### Description
- Update `assert("uavs", 1000)` to `assert("uavs", 2500)` in the JSON validation script at `.github/workflows/pr-loss-auto-check/index.js`.

### Testing
- No automated tests were executed for this trivial threshold change; the repository's PR validation workflow will run this check when the PR is opened.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6981a51f60bc832f8a34eedb27fa87c7)