### PR TITLE
ci: updated range validation for unarmored vehicles

### DIFF
--- a/.github/workflows/pr-loss-auto-check/index.js
+++ b/.github/workflows/pr-loss-auto-check/index.js
@@ -23,7 +23,7 @@ assert("rocketSystems", 250);
 assert("airDefense", 250);
 assert("ships", 50);
 assert("submarines", 50);
-assert("unarmoredVehicles", 250);
+assert("unarmoredVehicles", 500);
 assert("specialEquipment", 250);
 assert("uavs", 2500);
 assert("missiles", 1000);


### PR DESCRIPTION
Increased the assert value for unarmoredVehicles from 250 to 500 as MoD Ukraine has been reporting 250+ losses frequently.