### PR TITLE
chore: update losses 2026-06-09

### DIFF
--- a/russian-losses.json
+++ b/russian-losses.json
@@ -1,5 +1,23 @@
 [
   {
+    "date": "2026-06-09",
+    "sourceUri": "https://mod.gov.ua/news/bojovi-vtrati-voroga-na-9-chervnya-2026-roku",
+    "personnel": 1376320,
+    "tanks": 12001,
+    "afvs": 24710,
+    "artillery": 43639,
+    "airDefense": 1411,
+    "rocketSystems": 1851,
+    "unarmoredVehicles": 104796,
+    "fixedWingAircraft": 436,
+    "rotaryWingAircraft": 353,
+    "uavs": 338327,
+    "ships": 33,
+    "submarines": 2,
+    "specialEquipment": 4263,
+    "missiles": 4733
+  },
+  {
     "date": "2026-06-08",
     "sourceUri": "https://mod.gov.ua/news/bojovi-vtrati-voroga-na-8-chervnya-2026-roku",
     "personnel": 1374950,


### PR DESCRIPTION
# Russian losses in Ukraine 2026-06-09 - 2026-06-08
Source: https://mod.gov.ua/news/bojovi-vtrati-voroga-na-9-chervnya-2026-roku

```diff
@@ personnel @@
- 1374950
+ 1376320
# 1370 difference

@@ artillery @@
- 43564
+ 43639
# 75 difference

@@ fixedWingAircraft @@
- 436
+ 436
# 0 difference

@@ rotaryWingAircraft @@
- 353
+ 353
# 0 difference

@@ tanks @@
- 11997
+ 12001
# 4 difference

@@ afvs @@
- 24705
+ 24710
# 5 difference

@@ rocketSystems @@
- 1847
+ 1851
# 4 difference

@@ airDefense @@
- 1409
+ 1411
# 2 difference

@@ ships @@
- 33
+ 33
# 0 difference

@@ submarines @@
- 2
+ 2
# 0 difference

@@ unarmoredVehicles @@
- 104414
+ 104796
# 382 difference

@@ specialEquipment @@
- 4259
+ 4263
# 4 difference

@@ uavs @@
- 336224
+ 338327
# 2103 difference

@@ missiles @@
- 4733
+ 4733
# 0 difference

```